### PR TITLE
gateware/ice40-stub: Support for dump shells

### DIFF
--- a/gateware/ice40-stub/Makefile
+++ b/gateware/ice40-stub/Makefile
@@ -48,7 +48,7 @@ $(FW_PROJ_BASE)/fw_dfu.bin:
 	make -C $(FW_PROJ_BASE) fw_dfu.bin
 
 bootloader-clean:
-	if [ "$(PRE_CLEAN)" == "1" ]; then \
+	if test "$(PRE_CLEAN)" = "1"; then \
 		make clean; \
 		make -C $(GW_PROJ_BASE) clean; \
 		make -C $(FW_PROJ_BASE) clean; \


### PR DESCRIPTION
The `[]` shell syntax is not available in every situation. The older and more portable solution is to use the `test` command instead.