### PR TITLE
contrib/jenkins.sh: Fix hostname for binary uploads

### DIFF
--- a/contrib/jenkins.sh
+++ b/contrib/jenkins.sh
@@ -34,9 +34,9 @@ mkdir "$deps" || true
 BOARDS="icebreaker bitsy_v0 bitsy_v1 ice1usb icepick e1tracer fomu_hacker fomu_pvt1"
 
 cat > "/build/known_hosts" <<EOF
-[rita.osmocom.org]:48 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDgQ9HntlpWNmh953a2Gc8NysKE4orOatVT1wQkyzhARnfYUerRuwyNr1GqMyBKdSI9amYVBXJIOUFcpV81niA7zQRUs66bpIMkE9/rHxBd81SkorEPOIS84W4vm3SZtuNqa+fADcqe88Hcb0ZdTzjKILuwi19gzrQyME2knHY71EOETe9Yow5RD2hTIpB5ecNxI0LUKDq+Ii8HfBvndPBIr0BWYDugckQ3Bocf+yn/tn2/GZieFEyFpBGF/MnLbAAfUKIdeyFRX7ufaiWWz5yKAfEhtziqdAGZaXNaLG6gkpy3EixOAy6ZXuTAk3b3Y0FUmDjhOHllbPmTOcKMry9
-[rita.osmocom.org]:48 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPdWn1kEousXuKsZ+qJEZTt/NSeASxCrUfNDW3LWtH+d8Ust7ZuKp/vuyG+5pe5pwpPOgFu7TjN+0lVjYJVXH54=
-[rita.osmocom.org]:48 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK8iivY70EiR5NiGChV39gRLjNpC8lvu1ZdHtdMw2zuX
+[ftp.osmocom.org]:48 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDgQ9HntlpWNmh953a2Gc8NysKE4orOatVT1wQkyzhARnfYUerRuwyNr1GqMyBKdSI9amYVBXJIOUFcpV81niA7zQRUs66bpIMkE9/rHxBd81SkorEPOIS84W4vm3SZtuNqa+fADcqe88Hcb0ZdTzjKILuwi19gzrQyME2knHY71EOETe9Yow5RD2hTIpB5ecNxI0LUKDq+Ii8HfBvndPBIr0BWYDugckQ3Bocf+yn/tn2/GZieFEyFpBGF/MnLbAAfUKIdeyFRX7ufaiWWz5yKAfEhtziqdAGZaXNaLG6gkpy3EixOAy6ZXuTAk3b3Y0FUmDjhOHllbPmTOcKMry9
+[ftp.osmocom.org]:48 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPdWn1kEousXuKsZ+qJEZTt/NSeASxCrUfNDW3LWtH+d8Ust7ZuKp/vuyG+5pe5pwpPOgFu7TjN+0lVjYJVXH54=
+[ftp.osmocom.org]:48 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK8iivY70EiR5NiGChV39gRLjNpC8lvu1ZdHtdMw2zuX
 EOF
 
 SSH_COMMAND="ssh -o 'UserKnownHostsFile=/build/known_hosts' -p 48"
@@ -52,10 +52,10 @@ for b in $BOARDS; do
 	if [ "x$publish" = "x--publish" ]; then
 		rsync --archive --verbose --compress --rsh "$SSH_COMMAND" \
 			$TOPDIR/firmware/no2bootloader-$b-*-*.{bin,elf} \
-			binaries@rita.osmocom.org:web-files/no2bootloader/$b/all/
+			binaries@ftp.osmocom.org:web-files/no2bootloader/$b/all/
 		rsync --archive --copy-links --verbose --compress --rsh "$SSH_COMMAND" \
 			$TOPDIR/firmware/no2bootloader-$b.{bin,elf} \
-			binaries@rita.osmocom.org:web-files/no2bootloader/$b/latest/
+			binaries@ftp.osmocom.org:web-files/no2bootloader/$b/latest/
 	fi
 done
 


### PR DESCRIPTION
The hostname for publishing on ftp.osmocom.org should always
have been ftp.osmocom.org, and not the real underlying host name.

As we've now moved from rita.osmocom.org to a new server, this
breaks.  Let's use the service/symbolic host name ftp.osmocom.org
to prevent this from repeating itself should we ever migrate again
in the future.

Related: Related: OS#3257 (https://osmocom.org/issues/3257)