### PR TITLE
Fixed a warning from gawk 5 or newer.

### DIFF
--- a/gateware/ice40-stub/Makefile
+++ b/gateware/ice40-stub/Makefile
@@ -12,8 +12,8 @@ PROJ_TOP_MOD := top
 
 # Target config
 BOARD ?= icebreaker
-DEVICE := $(shell awk '/^\#\# dev:/{print $$3; exit 1}' data/top-$(BOARD).pcf && echo up5k)
-PACKAGE := $(shell awk '/^\#\# pkg:/{print $$3; exit 1}' data/top-$(BOARD).pcf && echo sg48)
+DEVICE := $(shell awk '/^## dev:/{print $$3; exit 1}' data/top-$(BOARD).pcf && echo up5k)
+PACKAGE := $(shell awk '/^## pkg:/{print $$3; exit 1}' data/top-$(BOARD).pcf && echo sg48)
 
 NEXTPNR_ARGS = --freq 48 --no-promote-globals
 

--- a/gateware/ice40/Makefile
+++ b/gateware/ice40/Makefile
@@ -26,8 +26,8 @@ PROJ_TOP_MOD := top
 
 # Target config
 BOARD ?= icebreaker
-DEVICE := $(shell awk '/^\#\# dev:/{print $$3; exit 1}' data/top-$(BOARD).pcf && echo up5k)
-PACKAGE := $(shell awk '/^\#\# pkg:/{print $$3; exit 1}' data/top-$(BOARD).pcf && echo sg48)
+DEVICE := $(shell awk '/^## dev:/{print $$3; exit 1}' data/top-$(BOARD).pcf && echo up5k)
+PACKAGE := $(shell awk '/^## pkg:/{print $$3; exit 1}' data/top-$(BOARD).pcf && echo sg48)
 
 SEED ?= 10
 NEXTPNR_ARGS = --pre-pack data/clocks.py --seed $(SEED)


### PR DESCRIPTION
It seems to be a known issue. Removing the escapes is the recommended fix. 
It is not clear if this change breaks something for older versions of awk or not.

This is why I am providing an alternative pull request that fixes the issue by getting rid of the awk use. Feel free to choose the solution you prefer. :)