### PR TITLE
Fixes an awk warning by replacing it with grep and make text function.

### DIFF
--- a/gateware/ice40-stub/Makefile
+++ b/gateware/ice40-stub/Makefile
@@ -12,8 +12,8 @@ PROJ_TOP_MOD := top
 
 # Target config
 BOARD ?= icebreaker
-DEVICE := $(shell awk '/^\#\# dev:/{print $$3; exit 1}' data/top-$(BOARD).pcf && echo up5k)
-PACKAGE := $(shell awk '/^\#\# pkg:/{print $$3; exit 1}' data/top-$(BOARD).pcf && echo sg48)
+DEVICE := $(lastword $(shell grep '^## dev:' data/top-$(BOARD).pcf || echo up5k))
+PACKAGE := $(lastword $(shell grep '^## pkg:' data/top-$(BOARD).pcf || echo sg48))
 
 NEXTPNR_ARGS = --freq 48 --no-promote-globals
 


### PR DESCRIPTION
It seems that gnuawk 5 and newer does not like the '\#'. It can be fixed by removing the '\' escape but it is not clear if it will break on older versions or not. It is probably safer to not use it at all.

This is the alternative fix for the awk issue. :)